### PR TITLE
Feature/functional utility

### DIFF
--- a/include/Simple-Utility/functional/transform.hpp
+++ b/include/Simple-Utility/functional/transform.hpp
@@ -9,7 +9,6 @@
 #pragma once
 
 #include "Simple-Utility/unified_base.hpp"
-#include "Simple-Utility/concepts/stl_extensions.hpp"
 #include "Simple-Utility/concepts/operators.hpp"
 #include "Simple-Utility/functional/base.hpp"
 #include "Simple-Utility/functional/operators/bind.hpp"
@@ -76,31 +75,6 @@ namespace sl::functional
 	 */
 	template <class TFunc>
 	transform_fn(TFunc) -> transform_fn<TFunc>;
-
-	namespace detail
-	{
-		template <class TTarget>
-		struct as_fn
-		{
-			template <concepts::explicitly_convertible_to<TTarget> TFrom>
-			[[nodiscard]]
-			constexpr TTarget operator ()
-			(
-				TFrom&& v
-			) const
-				noexcept(concepts::nothrow_explicitly_convertible_to<TFrom, TTarget>)
-			{
-				return static_cast<TTarget>(std::forward<TFrom>(v));
-			}
-		};
-	}
-
-	/**
-	 * \brief Functional object which static_cast the given argument to the target type on invocation.
-	 * \tparam TTarget The target type.
-	 */
-	template <class TTarget>
-	inline constexpr transform_fn as{ detail::as_fn<TTarget>{} };
 
 	/** @} */
 

--- a/include/Simple-Utility/functional/utility.hpp
+++ b/include/Simple-Utility/functional/utility.hpp
@@ -1,4 +1,4 @@
-//          Copyright Dominic Koepke 2019 - 2022.
+//          Copyright Dominic Koepke 2019 - 2023.
 // Distributed under the Boost Software License, Version 1.0.
 //    (See accompanying file LICENSE_1_0.txt or copy at
 //          https://www.boost.org/LICENSE_1_0.txt)

--- a/include/Simple-Utility/functional/utility.hpp
+++ b/include/Simple-Utility/functional/utility.hpp
@@ -8,8 +8,9 @@
 
 #pragma once
 
-#include "Simple-Utility/functional/transform.hpp"
+#include "Simple-Utility/concepts/operators.hpp"
 #include "Simple-Utility/concepts/stl_extensions.hpp"
+#include "Simple-Utility/functional/transform.hpp"
 
 #include <utility>
 
@@ -33,6 +34,18 @@ namespace sl::functional::util
 			static_assert(concepts::explicitly_convertible_to<TFrom, TTo>, "Argument is not convertible to target type.");
 
 			return static_cast<TTo>(std::forward<TFrom>(arg));
+		}
+	};
+
+	/**
+	 * \brief Functional object which dereferences the given argument and returns the result.
+	 */
+	inline constexpr transform_fn dereference{
+		[]<class T>(T&& arg) constexpr noexcept(noexcept(*std::forward<T>(arg))) -> decltype(auto)
+		{
+			static_assert(concepts::dereferencable<T>, "Argument is not usable as operand of unary operator *.");
+
+			return *std::forward<T>(arg);
 		}
 	};
 

--- a/include/Simple-Utility/functional/utility.hpp
+++ b/include/Simple-Utility/functional/utility.hpp
@@ -1,0 +1,42 @@
+//          Copyright Dominic Koepke 2019 - 2022.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          https://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef SL_UTILITY_FUNCTIONAL_UTILITY_HPP
+#define SL_UTILITY_FUNCTIONAL_UTILITY_HPP
+
+#pragma once
+
+#include "Simple-Utility/functional/transform.hpp"
+#include "Simple-Utility/concepts/stl_extensions.hpp"
+
+#include <utility>
+
+namespace sl::functional::util
+{
+	/**
+	 * \defgroup GROUP_FUNCTIONAL_UTILITY utility
+	 * \brief Contains functional objects, implementing several utility operations.
+	 * \ingroup GROUP_FUNCTIONAL
+	 * @{
+	 */
+
+	/**
+	 * \brief Functional object which converts the given argument to the target type via static_cast.
+	 * \tparam TTo The target type.
+	 */
+	template <class TTo>
+	inline constexpr transform_fn as{
+		[]<class TFrom>(TFrom&& arg) constexpr noexcept(concepts::nothrow_explicitly_convertible_to<TFrom, TTo>) -> TTo
+		{
+			static_assert(concepts::explicitly_convertible_to<TFrom, TTo>, "Argument is not convertible to target type.");
+
+			return static_cast<TTo>(std::forward<TFrom>(arg));
+		}
+	};
+
+	/** @} */
+}
+
+#endif

--- a/include/Simple-Utility/functional/utility.hpp
+++ b/include/Simple-Utility/functional/utility.hpp
@@ -12,6 +12,7 @@
 #include "Simple-Utility/concepts/stl_extensions.hpp"
 #include "Simple-Utility/functional/transform.hpp"
 
+#include <memory>
 #include <utility>
 
 namespace sl::functional::util
@@ -46,6 +47,19 @@ namespace sl::functional::util
 			static_assert(concepts::dereferencable<T>, "Argument is not usable as operand of unary operator *.");
 
 			return *std::forward<T>(arg);
+		}
+	};
+
+	/**
+	 * \brief Functional object which returns the address of the given argument.
+	 * \see https://en.cppreference.com/w/cpp/memory/addressof
+	 */
+	inline constexpr transform_fn addressof{
+		[](auto& arg) constexpr noexcept
+		{
+			static_assert(requires { std::addressof(arg); }, "Argument is not usable for std::addressof.");
+
+			return std::addressof(arg);
 		}
 	};
 

--- a/tests/functional/CMakeLists.txt
+++ b/tests/functional/CMakeLists.txt
@@ -6,4 +6,5 @@ target_sources(
 	"transform.cpp"
 	"tuple.cpp"
 	"overloaded.cpp"
+	"utility.cpp"
 )

--- a/tests/functional/transform.cpp
+++ b/tests/functional/transform.cpp
@@ -10,8 +10,6 @@
 
 #include "Simple-Utility/functional/transform.hpp"
 
-#include <optional>
-
 using namespace sl::functional;
 
 namespace
@@ -192,37 +190,6 @@ TEST_CASE("back curried transform_fn can be piped", "[functional][transform]")
 							| transform_fn{std::multiplies{}} >> 2;
 
 	REQUIRE(transform(7, 3) == 100);
-}
-
-template <class T>
-struct explicitly_constructible
-{
-	T t{};
-
-	explicit explicitly_constructible(T t)
-		: t{t}
-	{
-	}
-
-	[[nodiscard]]
-	bool operator ==(T other) const
-	{
-		return t == other;
-	}
-};
-
-TEMPLATE_TEST_CASE_SIG(
-	"as casts the given parameter when invoked.",
-	"[functional][transform]",
-	((class TTarget, auto VSource, auto VExpected), TTarget, VSource, VExpected),
-	(int, 42ul, 42),
-	(char, 42, '*'),
-	(std::optional<int>, 3, 3),
-	(explicitly_constructible<int>, 1337, 1337)
-)
-{
-	STATIC_REQUIRE(std::same_as<TTarget, decltype(as<TTarget>(VSource))>);
-	REQUIRE(as<TTarget>(VSource) == VExpected);
 }
 
 TEST_CASE("plus forwards the params to operator + and returns the result.", "[functional][transform][arithmetic]")

--- a/tests/functional/utility.cpp
+++ b/tests/functional/utility.cpp
@@ -41,18 +41,21 @@ TEMPLATE_TEST_CASE_SIG(
 	REQUIRE(util::as<TTarget>(VSource) == VExpected);
 }
 
-TEST_CASE("util::dereference uses the dereferencing operator on the argument and returns the result.", "[functional][transform][utility]")
+TEST_CASE(
+	"util::dereference uses the dereferencing operator on the argument and returns the result.",
+	"[functional][transform][utility]"
+)
 {
-	const std::optional<int> opt{42};
+	std::optional<int> opt{ 42 };
 
-	const int value{ util::dereference(opt) };
-
-	REQUIRE(value == 42);
+	REQUIRE(util::dereference(opt) == 42);
+	REQUIRE(util::dereference(std::as_const(opt)) == 42);
+	REQUIRE(util::dereference(std::move(opt)) == 42);
 }
 
 TEST_CASE("util::addressof returns the address of the given argument.", "[functional][transform][utility]")
 {
-	int value{1337};
+	int value{ 1337 };
 
 	REQUIRE(util::addressof(value) == &value);
 	REQUIRE(util::addressof(std::as_const(value)) == &value);

--- a/tests/functional/utility.cpp
+++ b/tests/functional/utility.cpp
@@ -1,4 +1,4 @@
-//          Copyright Dominic Koepke 2019 - 2022.
+//          Copyright Dominic Koepke 2019 - 2023.
 // Distributed under the Boost Software License, Version 1.0.
 //    (See accompanying file LICENSE_1_0.txt or copy at
 //          https://www.boost.org/LICENSE_1_0.txt)
@@ -17,8 +17,9 @@ struct explicitly_constructible
 	T t{};
 
 	explicit explicitly_constructible(T t)
-		: t{ t }
-	{}
+		: t{t}
+	{
+	}
 
 	[[nodiscard]]
 	bool operator ==(T other) const
@@ -46,7 +47,7 @@ TEST_CASE(
 	"[functional][transform][utility]"
 )
 {
-	std::optional<int> opt{ 42 };
+	std::optional<int> opt{42};
 
 	REQUIRE(util::dereference(opt) == 42);
 	REQUIRE(util::dereference(std::as_const(opt)) == 42);
@@ -55,7 +56,7 @@ TEST_CASE(
 
 TEST_CASE("util::addressof returns the address of the given argument.", "[functional][transform][utility]")
 {
-	int value{ 1337 };
+	int value{1337};
 
 	REQUIRE(util::addressof(value) == &value);
 	REQUIRE(util::addressof(std::as_const(value)) == &value);

--- a/tests/functional/utility.cpp
+++ b/tests/functional/utility.cpp
@@ -5,6 +5,8 @@
 
 #include <catch2/catch_template_test_macros.hpp>
 
+#include <optional>
+
 #include "Simple-Utility/functional/utility.hpp"
 
 using namespace sl::functional;
@@ -37,4 +39,13 @@ TEMPLATE_TEST_CASE_SIG(
 {
 	STATIC_REQUIRE(std::same_as<TTarget, decltype(util::as<TTarget>(VSource))>);
 	REQUIRE(util::as<TTarget>(VSource) == VExpected);
+}
+
+TEST_CASE("util::derefence uses the dereferencing operator on the argument and returns the result.", "[functional][transform][utility]")
+{
+	const std::optional<int> opt{42};
+
+	const int value{ util::dereference(opt) };
+
+	REQUIRE(value == 42);
 }

--- a/tests/functional/utility.cpp
+++ b/tests/functional/utility.cpp
@@ -1,0 +1,40 @@
+//          Copyright Dominic Koepke 2019 - 2022.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          https://www.boost.org/LICENSE_1_0.txt)
+
+#include <catch2/catch_template_test_macros.hpp>
+
+#include "Simple-Utility/functional/utility.hpp"
+
+using namespace sl::functional;
+
+template <class T>
+struct explicitly_constructible
+{
+	T t{};
+
+	explicit explicitly_constructible(T t)
+		: t{ t }
+	{}
+
+	[[nodiscard]]
+	bool operator ==(T other) const
+	{
+		return t == other;
+	}
+};
+
+TEMPLATE_TEST_CASE_SIG(
+	"as casts the given argument when invoked.",
+	"[functional][transform][utility]",
+	((class TTarget, auto VSource, auto VExpected), TTarget, VSource, VExpected),
+	(int, 42ul, 42),
+	(char, 42, '*'),
+	(std::optional<int>, 3, 3),
+	(explicitly_constructible<int>, 1337, 1337)
+)
+{
+	STATIC_REQUIRE(std::same_as<TTarget, decltype(util::as<TTarget>(VSource))>);
+	REQUIRE(util::as<TTarget>(VSource) == VExpected);
+}

--- a/tests/functional/utility.cpp
+++ b/tests/functional/utility.cpp
@@ -41,11 +41,19 @@ TEMPLATE_TEST_CASE_SIG(
 	REQUIRE(util::as<TTarget>(VSource) == VExpected);
 }
 
-TEST_CASE("util::derefence uses the dereferencing operator on the argument and returns the result.", "[functional][transform][utility]")
+TEST_CASE("util::dereference uses the dereferencing operator on the argument and returns the result.", "[functional][transform][utility]")
 {
 	const std::optional<int> opt{42};
 
 	const int value{ util::dereference(opt) };
 
 	REQUIRE(value == 42);
+}
+
+TEST_CASE("util::addressof returns the address of the given argument.", "[functional][transform][utility]")
+{
+	int value{1337};
+
+	REQUIRE(util::addressof(value) == &value);
+	REQUIRE(util::addressof(std::as_const(value)) == &value);
 }

--- a/tests/nullables/adapter.cpp
+++ b/tests/nullables/adapter.cpp
@@ -17,6 +17,7 @@
 #include "Simple-Utility/nullables/std_optional.hpp"
 
 #include "Simple-Utility/functional/tuple.hpp"
+#include "Simple-Utility/functional/utility.hpp"
 
 #include <algorithm>
 #include <map>
@@ -156,7 +157,7 @@ TEST_CASE("fsdadapter can be constructed from borrowed ranges and reassigned lat
 	const std::vector v{1, 2, 3, 4};
 
 	const int value = (adapter{v} = std::ranges::find(v, 2))
-					| and_then(sl::functional::as<std::optional<int>>)
+					| and_then(sl::functional::util::as<std::optional<int>>)
 					| value_or(1337);
 
 	REQUIRE(value == 2);
@@ -198,7 +199,7 @@ TEST_CASE("adapter can simplfy code dealing with iterators.", "[nullables][adapt
 	const auto get_from_storage_adapted = [&](const int key)
 	{
 		return na::adapter{global_storage.end(), global_storage.find(key)}
-				| na::and_then(fn::tuple::get_at<1> | fn::as<std::optional<std::string_view>>);
+				| na::and_then(fn::tuple::get_at<1> | fn::util::as<std::optional<std::string_view>>);
 	};
 	//! [adapter comparison]
 

--- a/tests/nullables/algorithm.cpp
+++ b/tests/nullables/algorithm.cpp
@@ -16,6 +16,7 @@
 
 #include "Simple-Utility/functional/predicate.hpp"
 #include "Simple-Utility/functional/transform.hpp"
+#include "Simple-Utility/functional/utility.hpp"
 
 #include <stdexcept>
 
@@ -57,9 +58,9 @@ TEMPLATE_LIST_TEST_CASE(
 			})
 	);
 
-	const sl::functional::transform_fn transform = std::identity{}
+	const sf::transform_fn transform = std::identity{}
 													| value_or_fn('x')
-													| sl::functional::as<int>;
+													| sf::util::as<int>;
 
 	REQUIRE(transform(TestType::cast(sourceOptional)) == expected);
 }
@@ -98,7 +99,7 @@ TEMPLATE_LIST_TEST_CASE(
 	);
 
 	bool invoked{false};
-	const sl::functional::transform_fn transform = std::identity{}
+	const sf::transform_fn transform = std::identity{}
 													| fwd_value_fn([&invoked](const char) { invoked = true; });
 
 	transform(TestType::cast(sourceOptional));
@@ -118,7 +119,7 @@ TEMPLATE_LIST_TEST_CASE(
 			{ nullptr, std::nullopt }
 			})
 	);
-	auto algorithm = and_then(sl::functional::as<std::optional<char>>);
+	auto algorithm = and_then(sf::util::as<std::optional<char>>);
 
 	const std::optional<char> s = TestType::cast_lhs(sourceOptional) | TestType::cast_rhs(algorithm);
 
@@ -137,8 +138,8 @@ TEMPLATE_LIST_TEST_CASE(
 			{ nullptr, false }
 			})
 	);
-	const sl::functional::transform_fn transform = std::identity{}
-													| and_then_fn(sl::functional::as<std::optional<char>>)
+	const sf::transform_fn transform = std::identity{}
+													| and_then_fn(sf::util::as<std::optional<char>>)
 													| &std::optional<char>::has_value;
 
 	REQUIRE(transform(TestType::cast(sourceOptional)) == expected);
@@ -192,10 +193,10 @@ TEMPLATE_LIST_TEST_CASE(
 			})
 	);
 
-	const sl::functional::predicate_fn predicate = std::identity{}
+	const sf::predicate_fn predicate = std::identity{}
 													| or_else_fn([] { throw std::exception{}; })
 													| [](auto t) { return t; }
-													| sl::functional::equal >> nullptr;
+													| sf::equal >> nullptr;
 
 	if (expectThrow)
 	{
@@ -343,7 +344,7 @@ TEST_CASE(
 								| and_then(
 									square
 									| to_string
-									| fn::as<std::optional<std::string>>
+									| fn::util::as<std::optional<std::string>>
 								)
 								| value_or("not set");
 
@@ -366,7 +367,7 @@ TEST_CASE(
 								| and_then_fn(
 									square
 									| to_string
-									| fn::as<std::optional<std::string>>
+									| fn::util::as<std::optional<std::string>>
 								)
 								| value_or_fn("not set");
 

--- a/tests/nullables/algorithm.cpp
+++ b/tests/nullables/algorithm.cpp
@@ -58,9 +58,9 @@ TEMPLATE_LIST_TEST_CASE(
 			})
 	);
 
-	const sf::transform_fn transform = std::identity{}
+	const sl::functional::transform_fn transform = std::identity{}
 													| value_or_fn('x')
-													| sf::util::as<int>;
+													| sl::functional::util::as<int>;
 
 	REQUIRE(transform(TestType::cast(sourceOptional)) == expected);
 }
@@ -99,7 +99,7 @@ TEMPLATE_LIST_TEST_CASE(
 	);
 
 	bool invoked{false};
-	const sf::transform_fn transform = std::identity{}
+	const sl::functional::transform_fn transform = std::identity{}
 													| fwd_value_fn([&invoked](const char) { invoked = true; });
 
 	transform(TestType::cast(sourceOptional));
@@ -119,7 +119,7 @@ TEMPLATE_LIST_TEST_CASE(
 			{ nullptr, std::nullopt }
 			})
 	);
-	auto algorithm = and_then(sf::util::as<std::optional<char>>);
+	auto algorithm = and_then(sl::functional::util::as<std::optional<char>>);
 
 	const std::optional<char> s = TestType::cast_lhs(sourceOptional) | TestType::cast_rhs(algorithm);
 
@@ -138,8 +138,8 @@ TEMPLATE_LIST_TEST_CASE(
 			{ nullptr, false }
 			})
 	);
-	const sf::transform_fn transform = std::identity{}
-													| and_then_fn(sf::util::as<std::optional<char>>)
+	const sl::functional::transform_fn transform = std::identity{}
+													| and_then_fn(sl::functional::util::as<std::optional<char>>)
 													| &std::optional<char>::has_value;
 
 	REQUIRE(transform(TestType::cast(sourceOptional)) == expected);
@@ -193,10 +193,10 @@ TEMPLATE_LIST_TEST_CASE(
 			})
 	);
 
-	const sf::predicate_fn predicate = std::identity{}
+	const sl::functional::predicate_fn predicate = std::identity{}
 													| or_else_fn([] { throw std::exception{}; })
 													| [](auto t) { return t; }
-													| sf::equal >> nullptr;
+													| sl::functional::equal >> nullptr;
 
 	if (expectThrow)
 	{


### PR DESCRIPTION
- moves ``as`` into ``functional::util`` namespace
- adds ``util::dereference`` and ``util::addressof`` functionals