### PR TITLE
Version 2.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ static_assert(std::same_as<
 		tl::TypeList<int&, int>,
 		tl::TypeList<int, int&>>>);
 
-using Zipped = tl::zip_as_t<std::tuple, MyTypesCart2, std::tuple<float, double>>;	// note the _as prefix. This is necessary if different type-list templates are combined.
+using Zipped = tl::zip_as_t<std::tuple, MyTypesCart2, std::tuple<float, double>>;	// note the _as suffix. This is necessary if different type-list templates are combined.
 
 static_assert(std::same_as<
 	Zipped,

--- a/include/Simple-Utility/Config.hpp
+++ b/include/Simple-Utility/Config.hpp
@@ -23,7 +23,7 @@
 
 #define SL_UTILITY_VERSION_MAJOR 2  // NOLINT(modernize-macro-to-enum)
 #define SL_UTILITY_VERSION_MINOR 2  // NOLINT(modernize-macro-to-enum)
-#define SL_UTILITY_VERSION_PATCH 0  // NOLINT(modernize-macro-to-enum)
+#define SL_UTILITY_VERSION_PATCH 1  // NOLINT(modernize-macro-to-enum)
 
 #define SL_UTILITY_VERSION \
     SL_UTILITY_XSTR(SL_UTILITY_VERSION_MAJOR) \

--- a/include/Simple-Utility/TypeList.hpp
+++ b/include/Simple-Utility/TypeList.hpp
@@ -95,7 +95,6 @@ namespace sl::concepts
 	 * \brief Determines whether a type satisfies the requirements of a type-list.
 	 * \details Requires the traits ``std::tuple_size`` to be specialized for the given type and its member ``value`` denoting the the correct tuple size.
 	 * The ``std::tuple_element`` trait must be defined for each index in the interval ``[0, N)``, where ``N`` is the size of the given type-list.
-	 * \concept type_list_like
 	 * \ingroup GROUP_TYPE_LIST GROUP_UTILITY_CONCEPTS
 	 * \see https://en.cppreference.com/w/cpp/utility/tuple_element
 	 * \see https://en.cppreference.com/w/cpp/utility/tuple_size

--- a/include/Simple-Utility/functional/base.hpp
+++ b/include/Simple-Utility/functional/base.hpp
@@ -432,7 +432,7 @@ namespace sl::functional
 		using value_type = T;
 
 	private:
-		value_type m_Value{};
+		T m_Value{};
 
 	public:
 		/**
@@ -479,42 +479,12 @@ namespace sl::functional
 
 		/**
 		 * \brief The invocation operator.
-		 * \return Returns a const lvalue reference to value.
+		 * \return The value object.
 		 */
 		[[nodiscard]]
-		constexpr const value_type& operator ()() const & noexcept
+		constexpr std::unwrap_reference_t<T> operator ()() const
 		{
 			return m_Value;
-		}
-
-		/**
-		 * \brief The invocation operator.
-		 * \return Returns a const lvalue reference to value.
-		 */
-		[[nodiscard]]
-		constexpr const value_type& operator ()() & noexcept
-		{
-			return m_Value;
-		}
-
-		/**
-		 * \brief The invocation operator.
-		 * \return Returns a const rvalue reference to value.
-		 */
-		[[nodiscard]]
-		constexpr const value_type&& operator ()() const && noexcept
-		{
-			return std::move(m_Value);
-		}
-
-		/**
-		 * \brief The invocation operator.
-		 * \return Returns a rvalue reference to value.
-		 */
-		[[nodiscard]]
-		constexpr value_type&& operator ()() && noexcept
-		{
-			return std::move(m_Value);
 		}
 	};
 

--- a/tests/functional/base.cpp
+++ b/tests/functional/base.cpp
@@ -146,26 +146,27 @@ TEMPLATE_PRODUCT_TEST_CASE(
 	STATIC_REQUIRE(std::same_as<value_type, std::decay_t<TestType>>);
 }
 
-TEMPLATE_TEST_CASE(
+TEMPLATE_TEST_CASE_SIG(
 	"Invoking value_fn yields expected types.",
 	"[functional][base]",
-	int,
-	int*,
-	const int*,
-	std::string,
-	std::reference_wrapper<int>,
-	std::reference_wrapper<const int>
+	((bool dummy, class Expected, class Input), dummy, Expected, Input),
+	(true, int, int),
+	(true, int*, int*),
+	(true, const int*, const int*),
+	(true, std::string, std::string),
+	(true, int&, std::reference_wrapper<int>),
+	(true, const int&, std::reference_wrapper<const int>)
 )
 {
-	using const_lvalue_result_t = std::invoke_result_t<as_const_lvalue_ref_t<value_fn<TestType>>>;
-	using lvalue_result_t = std::invoke_result_t<as_lvalue_ref_t<value_fn<TestType>>>;
-	using const_rvalue_result_t = std::invoke_result_t<as_const_rvalue_ref_t<value_fn<TestType>>>;
-	using rvalue_result_t = std::invoke_result_t<as_rvalue_ref_t<value_fn<TestType>>>;
+	using const_lvalue_result_t = std::invoke_result_t<as_const_lvalue_ref_t<value_fn<Input>>>;
+	using lvalue_result_t = std::invoke_result_t<as_lvalue_ref_t<value_fn<Input>>>;
+	using const_rvalue_result_t = std::invoke_result_t<as_const_rvalue_ref_t<value_fn<Input>>>;
+	using rvalue_result_t = std::invoke_result_t<as_rvalue_ref_t<value_fn<Input>>>;
 
-	STATIC_REQUIRE(std::same_as<const_lvalue_result_t, as_const_lvalue_ref_t<TestType>>);
-	STATIC_REQUIRE(std::same_as<lvalue_result_t, as_const_lvalue_ref_t<TestType>>);
-	STATIC_REQUIRE(std::same_as<const_rvalue_result_t, as_const_rvalue_ref_t<TestType>>);
-	STATIC_REQUIRE(std::same_as<rvalue_result_t, as_rvalue_ref_t<TestType>>);
+	STATIC_REQUIRE(std::same_as<Expected, const_lvalue_result_t>);
+	STATIC_REQUIRE(std::same_as<Expected, lvalue_result_t>);
+	STATIC_REQUIRE(std::same_as<Expected, const_rvalue_result_t>);
+	STATIC_REQUIRE(std::same_as<Expected, rvalue_result_t>);
 }
 
 TEMPLATE_LIST_TEST_CASE("value_fn supports trivial types.", "[functional][base]", all_ref_mods_list)


### PR DESCRIPTION
## Fixes
* ``functional::value_fn`` correctly unwraps its value type when returned